### PR TITLE
feat: add support to user_bucket value

### DIFF
--- a/src/evaluator/getters.rs
+++ b/src/evaluator/getters.rs
@@ -28,14 +28,14 @@ pub fn get_numeric_value(v: &serde_json::Value) -> Option<f64> {
     }
 }
 
-pub fn get_string(v: &serde_json::Value) -> String {
+pub fn get_string(v: &serde_json::Value) -> Option<String> {
     match v {
-        serde_json::Value::Null => "".to_string(),
-        serde_json::Value::Bool(b) => b.to_string(),
-        serde_json::Value::Number(n) => n.to_string(),
-        serde_json::Value::String(s) => s.clone(),
-        serde_json::Value::Array(_) => "".to_string(),
-        serde_json::Value::Object(_) => "".to_string(),
+        serde_json::Value::Null => None,
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Array(_) => None,
+        serde_json::Value::Object(_) => None,
     }
 }
 

--- a/src/evaluator/models.rs
+++ b/src/evaluator/models.rs
@@ -96,7 +96,7 @@ pub struct ConfigCondition {
     pub operator: Option<OperatorType>,
     pub field: Option<String>,
     pub target_value: Option<serde_json::Value>,
-    // pub additional_values: Option<HashMap<String, String>>, // map[string]interface{}
+    pub additional_values: Option<HashMap<String, String>>,
     pub id_type: String,
 }
 


### PR DESCRIPTION
With this we can better cover the experiments, which use the user_bucket to attribute users to the different groups.