### PR TITLE
feat: generic get-config endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "statsig-rs"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "statsig-rs"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Unofficial crate to interact with statsig.io"
 repository = "https://github.com/reidopitaco/statsig-rs"

--- a/src/evaluator/models.rs
+++ b/src/evaluator/models.rs
@@ -10,6 +10,9 @@ pub struct EvalResult {
     pub fetch_from_server: bool,
     pub id: String,
     pub secondary_exposures: Vec<HashMap<String, String>>,
+    pub group: String,
+    pub group_name: String,
+    pub rule_id: String,
     // pub undelegated_secondary_exposures: Option<Vec<HashMap<String, String>>>,
     // pub config_delegate: Option<String>,
     // pub explicit_parameters: Option<HashMap<String, bool>>,
@@ -39,8 +42,11 @@ impl EvalResult {
             pass,
             fetch_from_server,
             config_value: None,
-            id: "default".to_string(),
+            id: "default".to_owned(),
             secondary_exposures: vec![],
+            group: "default".to_owned(),
+            group_name: "default".to_owned(),
+            rule_id: "default".to_owned(),
         }
     }
 }
@@ -86,6 +92,7 @@ pub struct ConfigRule {
     pub conditions: Vec<ConfigCondition>,
     pub return_value: serde_json::Value, // json.RawMessage
     pub id_type: String,
+    pub group_name: String,
     // pub config_delegate: String,
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -4,6 +4,15 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 
+#[derive(Serialize, Deserialize)]
+pub struct StatsigConfig<T> {
+    pub value: Option<T>,
+    pub name: String,
+    pub group_name: String,
+    pub rule_id: String,
+    pub group: String,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatsigPost {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -98,6 +98,7 @@ pub fn expect_fetch_config_specs(server: &Server) {
                         "idType": "userID",
                         "rules": [{
                             "name": "public",
+                            "groupName": "public",
                             "id": "public1",
                             "salt": "salt_rule",
                             "passPercentage": 100,


### PR DESCRIPTION
This PR creates the get_config function in Client, now we can use the https://api.statsig.com/v1/get_config without specifying the return to be the value field.

Return example:
`{
    "name": "yyyy",
    "value": {
        "z": "zzzz",
    },
    "group": "xxxx"
}`