### PR TITLE
chore: set timeout from env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "statsig-rs"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "statsig-rs"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Unofficial crate to interact with statsig.io"
 repository = "https://github.com/reidopitaco/statsig-rs"

--- a/src/http.rs
+++ b/src/http.rs
@@ -237,7 +237,6 @@ impl StatsigHttpClient {
         let response = Retry::spawn(retry_strategy, || async {
             self.http_client
                 .post(url.clone())
-                .timeout(Duration::from_secs(10))
                 .json(&body)
                 .send()
                 .await

--- a/src/http.rs
+++ b/src/http.rs
@@ -235,11 +235,7 @@ impl StatsigHttpClient {
             .map(jitter)
             .take(5);
         let response = Retry::spawn(retry_strategy, || async {
-            self.http_client
-                .post(url.clone())
-                .json(&body)
-                .send()
-                .await
+            self.http_client.post(url.clone()).json(&body).send().await
         })
         .await;
         let res = match response {


### PR DESCRIPTION
já tem o [timeout](https://github.com/reidopitaco/statsig-rs/blob/3a62d6f0a723baaa2668afca36ebf696f40b7bfc/src/http.rs#L39) do cliente, setado por variável de ambiente

acredito que quando os dois estão setados (cliente e request), pega o mínimo entre os dois, então podemos remover o da request