### PR TITLE
fix(statsig-rs): fixes missing group name

### DIFF
--- a/src/evaluator/models.rs
+++ b/src/evaluator/models.rs
@@ -82,7 +82,7 @@ pub enum ConfigSpecType {
     Unknown,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigRule {
     pub name: String,


### PR DESCRIPTION
> should be able to start statsig client: error parsing state response: error decoding response body: missing field `groupName` at line 1 column 875
